### PR TITLE
Feat: Missing Lvls, Enchant Preparation, Error reduction

### DIFF
--- a/Books/assets/firmskyblock/models/item/looting__6.json
+++ b/Books/assets/firmskyblock/models/item/looting__6.json
@@ -1,0 +1,6 @@
+{
+	"parent": "firmskyblock:item/looting__0",
+	"textures": {
+		"layer2": "sophie:item/numlays/six"
+	}
+}

--- a/Books/assets/firmskyblock/models/item/scavenger__6.json
+++ b/Books/assets/firmskyblock/models/item/scavenger__6.json
@@ -1,0 +1,6 @@
+{
+	"parent": "firmskyblock:item/scavenger__0",
+	"textures": {
+		"layer2": "sophie:item/numlays/six"
+	}
+}

--- a/Books/assets/firmskyblock/models/item/scuba__6.json
+++ b/Books/assets/firmskyblock/models/item/scuba__6.json
@@ -1,0 +1,6 @@
+{
+	"parent": "firmskyblock:item/scuba__0",
+	"textures": {
+		"layer2": "sophie:item/numlays/six"
+	}
+}

--- a/Books/assets/firmskyblock/models/item/venomous__7.json
+++ b/Books/assets/firmskyblock/models/item/venomous__7.json
@@ -1,0 +1,6 @@
+{
+	"parent": "firmskyblock:item/venomous__0",
+	"textures": {
+		"layer2": "sophie:item/numlays/seven"
+	}
+}

--- a/Books/assets/firmskyblock/models/item/vicious__6.json
+++ b/Books/assets/firmskyblock/models/item/vicious__6.json
@@ -1,0 +1,6 @@
+{
+	"parent": "firmskyblock:item/vicious__0",
+	"textures": {
+		"layer2": "sophie:item/numlays/six"
+	}
+}

--- a/Books/assets/skyblock/items/enchantments/looting.json
+++ b/Books/assets/skyblock/items/enchantments/looting.json
@@ -37,6 +37,13 @@
 					"type": "minecraft:model",
 					"model": "firmskyblock:item/looting__5"
 				}
+			},
+			{
+				"threshold": 6,
+				"model": {
+					"type": "minecraft:model",
+					"model": "firmskyblock:item/looting__6"
+				}
 			}
 		],
 		"fallback": {

--- a/Books/assets/skyblock/items/enchantments/scavenger.json
+++ b/Books/assets/skyblock/items/enchantments/scavenger.json
@@ -37,6 +37,13 @@
 					"type": "minecraft:model",
 					"model": "firmskyblock:item/scavenger__5"
 				}
+			},
+			{
+				"threshold": 6,
+				"model": {
+					"type": "minecraft:model",
+					"model": "firmskyblock:item/scavenger__6"
+				}
 			}
 		],
 		"fallback": {

--- a/Books/assets/skyblock/items/enchantments/scuba.json
+++ b/Books/assets/skyblock/items/enchantments/scuba.json
@@ -37,6 +37,13 @@
 					"type": "minecraft:model",
 					"model": "firmskyblock:item/scuba__5"
 				}
+			},
+			{
+				"threshold": 6,
+				"model": {
+					"type": "minecraft:model",
+					"model": "firmskyblock:item/scuba__6"
+				}
 			}
 		],
 		"fallback": {

--- a/Books/assets/skyblock/items/enchantments/sugar_rush.json
+++ b/Books/assets/skyblock/items/enchantments/sugar_rush.json
@@ -23,6 +23,13 @@
 					"type": "minecraft:model",
 					"model": "firmskyblock:item/sugar_rush__3"
 				}
+			},
+			{
+				"threshold": 4,
+				"model": {
+					"type": "minecraft:model",
+					"model": "firmskyblock:item/sugar_rush__4"
+				}
 			}
 		],
 		"fallback": {

--- a/Books/assets/skyblock/items/enchantments/turbo_wheat.json
+++ b/Books/assets/skyblock/items/enchantments/turbo_wheat.json
@@ -37,6 +37,20 @@
 					"type": "minecraft:model",
 					"model": "firmskyblock:item/turbo_wheat__5"
 				}
+			},
+			{
+				"threshold": 6,
+				"model": {
+					"type": "minecraft:model",
+					"model": "firmskyblock:item/turbo_wheat__6"
+				}
+			},
+			{
+				"threshold": 7,
+				"model": {
+					"type": "minecraft:model",
+					"model": "firmskyblock:item/turbo_wheat__7"
+				}
 			}
 		],
 		"fallback": {

--- a/Books/assets/skyblock/items/enchantments/ultimate_missile.json
+++ b/Books/assets/skyblock/items/enchantments/ultimate_missile.json
@@ -37,41 +37,6 @@
 					"type": "minecraft:model",
 					"model": "firmskyblock:item/ultimate_missile__5"
 				}
-			},
-			{
-				"threshold": 6,
-				"model": {
-					"type": "minecraft:model",
-					"model": "firmskyblock:item/ultimate_missile__6"
-				}
-			},
-			{
-				"threshold": 7,
-				"model": {
-					"type": "minecraft:model",
-					"model": "firmskyblock:item/ultimate_missile__7"
-				}
-			},
-			{
-				"threshold": 8,
-				"model": {
-					"type": "minecraft:model",
-					"model": "firmskyblock:item/ultimate_missile__8"
-				}
-			},
-			{
-				"threshold": 9,
-				"model": {
-					"type": "minecraft:model",
-					"model": "firmskyblock:item/ultimate_missile__9"
-				}
-			},
-			{
-				"threshold": 10,
-				"model": {
-					"type": "minecraft:model",
-					"model": "firmskyblock:item/ultimate_missile__10"
-				}
 			}
 		],
 		"fallback": {

--- a/Books/assets/skyblock/items/enchantments/ultimate_refrigerate.json
+++ b/Books/assets/skyblock/items/enchantments/ultimate_refrigerate.json
@@ -37,41 +37,6 @@
 					"type": "minecraft:model",
 					"model": "firmskyblock:item/ultimate_refrigerate__5"
 				}
-			},
-			{
-				"threshold": 6,
-				"model": {
-					"type": "minecraft:model",
-					"model": "firmskyblock:item/ultimate_refrigerate__6"
-				}
-			},
-			{
-				"threshold": 7,
-				"model": {
-					"type": "minecraft:model",
-					"model": "firmskyblock:item/ultimate_refrigerate__7"
-				}
-			},
-			{
-				"threshold": 8,
-				"model": {
-					"type": "minecraft:model",
-					"model": "firmskyblock:item/ultimate_refrigerate__8"
-				}
-			},
-			{
-				"threshold": 9,
-				"model": {
-					"type": "minecraft:model",
-					"model": "firmskyblock:item/ultimate_refrigerate__9"
-				}
-			},
-			{
-				"threshold": 10,
-				"model": {
-					"type": "minecraft:model",
-					"model": "firmskyblock:item/ultimate_refrigerate__10"
-				}
 			}
 		],
 		"fallback": {

--- a/Books/assets/skyblock/items/enchantments/ultimate_swarm.json
+++ b/Books/assets/skyblock/items/enchantments/ultimate_swarm.json
@@ -37,41 +37,6 @@
 					"type": "minecraft:model",
 					"model": "firmskyblock:item/ultimate_swarm__5"
 				}
-			},
-			{
-				"threshold": 6,
-				"model": {
-					"type": "minecraft:model",
-					"model": "firmskyblock:item/ultimate_swarm__6"
-				}
-			},
-			{
-				"threshold": 7,
-				"model": {
-					"type": "minecraft:model",
-					"model": "firmskyblock:item/ultimate_swarm__7"
-				}
-			},
-			{
-				"threshold": 8,
-				"model": {
-					"type": "minecraft:model",
-					"model": "firmskyblock:item/ultimate_swarm__8"
-				}
-			},
-			{
-				"threshold": 9,
-				"model": {
-					"type": "minecraft:model",
-					"model": "firmskyblock:item/ultimate_swarm__9"
-				}
-			},
-			{
-				"threshold": 10,
-				"model": {
-					"type": "minecraft:model",
-					"model": "firmskyblock:item/ultimate_swarm__10"
-				}
 			}
 		],
 		"fallback": {

--- a/Books/assets/skyblock/items/enchantments/venomous.json
+++ b/Books/assets/skyblock/items/enchantments/venomous.json
@@ -44,6 +44,13 @@
 					"type": "minecraft:model",
 					"model": "firmskyblock:item/venomous__6"
 				}
+			},
+			{
+				"threshold": 7,
+				"model": {
+					"type": "minecraft:model",
+					"model": "firmskyblock:item/venomous__7"
+				}
 			}
 		],
 		"fallback": {

--- a/Books/assets/skyblock/items/enchantments/vicious.json
+++ b/Books/assets/skyblock/items/enchantments/vicious.json
@@ -23,6 +23,13 @@
 					"type": "minecraft:model",
 					"model": "firmskyblock:item/vicious__5"
 				}
+			},
+			{
+				"threshold": 6,
+				"model": {
+					"type": "minecraft:model",
+					"model": "firmskyblock:item/vicious__6"
+				}
 			}
 		],
 		"fallback": {


### PR DESCRIPTION
- Added Cap faux books (for item list mods) for Scavenger and Venomous
- Added Cap faux books that don't currently exist (item list) for Looting VI, Scuba VI, and Vicious VI

- Fixed Sugar Rush IV, Turbo Wheat VI & VII not having support in Cats
- Fixed error spam from missing models from ultimate enchants Missile, Refrigerate, and Swarm.